### PR TITLE
Update "master" references to "main" to fix broken links in README table of contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,18 @@
-[principles]: https://github.com/ksindi/managers-playbook/blob/master/README.md#principles
-[one-on-ones]: https://github.com/ksindi/managers-playbook/blob/master/README.md#one-on-ones
-[coaching]: https://github.com/ksindi/managers-playbook/blob/master/README.md#coaching
-[feedback]: https://github.com/ksindi/managers-playbook/blob/master/README.md#feedback
-[thinking-strategically]: https://github.com/ksindi/managers-playbook/blob/master/README.md#thinking-strategically
-[making-decisions]: https://github.com/ksindi/managers-playbook/blob/master/README.md#making-decisions
-[coding]: https://github.com/ksindi/managers-playbook/blob/master/README.md#coding
-[ticket-and-pr-process]: https://github.com/ksindi/managers-playbook/blob/master/README.md#ticket-and-pr-process
-[communicating]: https://github.com/ksindi/managers-playbook/blob/master/README.md#communicating
-[hiring]: https://github.com/ksindi/managers-playbook/blob/master/README.md#hiring
-[onboarding]: https://github.com/ksindi/managers-playbook/blob/master/README.md#onboarding
-[announcing-change]: https://github.com/ksindi/managers-playbook/blob/master/README.md#announcing-change
-[managing-up]: https://github.com/ksindi/managers-playbook/blob/master/README.md#managing-up
-[managing-sideways]: https://github.com/ksindi/managers-playbook/blob/master/README.md#managing-sideways
-[further-reading]: https://github.com/ksindi/managers-playbook/blob/master/README.md#further-reading
+[principles]: https://github.com/ksindi/managers-playbook/blob/main/README.md#principles
+[one-on-ones]: https://github.com/ksindi/managers-playbook/blob/main/README.md#one-on-ones
+[coaching]: https://github.com/ksindi/managers-playbook/blob/main/README.md#coaching
+[feedback]: https://github.com/ksindi/managers-playbook/blob/main/README.md#feedback
+[thinking-strategically]: https://github.com/ksindi/managers-playbook/blob/main/README.md#thinking-strategically
+[making-decisions]: https://github.com/ksindi/managers-playbook/blob/main/README.md#making-decisions
+[coding]: https://github.com/ksindi/managers-playbook/blob/main/README.md#coding
+[ticket-and-pr-process]: https://github.com/ksindi/managers-playbook/blob/main/README.md#ticket-and-pr-process
+[communicating]: https://github.com/ksindi/managers-playbook/blob/main/README.md#communicating
+[hiring]: https://github.com/ksindi/managers-playbook/blob/main/README.md#hiring
+[onboarding]: https://github.com/ksindi/managers-playbook/blob/main/README.md#onboarding
+[announcing-change]: https://github.com/ksindi/managers-playbook/blob/main/README.md#announcing-change
+[managing-up]: https://github.com/ksindi/managers-playbook/blob/main/README.md#managing-up
+[managing-sideways]: https://github.com/ksindi/managers-playbook/blob/main/README.md#managing-sideways
+[further-reading]: https://github.com/ksindi/managers-playbook/blob/main/README.md#further-reading
 
 # Manager's Playbook
 


### PR DESCRIPTION
The default branch of this repo has been renamed to "main" from "master", which looks to have broken many of the anchor links in the table of contents. This PR updates the ToC links to refer to the new default branch name.